### PR TITLE
fix: max fee limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layerzerolabs/hardhat-deploy",
-  "version": "0.11.45-lz.2",
+  "version": "0.11.45-lz.4",
   "description": "Hardhat Plugin For Replicable Deployments And Tests",
   "repository": {
     "type": "git",

--- a/src/tron/tronweb.d.ts
+++ b/src/tron/tronweb.d.ts
@@ -355,7 +355,7 @@ declare module 'tronweb' {
       timestamp?: number,
       options?: Record<string, unknown>
     ): Promise<Record<string, unknown>>;
-    getChainParameters(): Promise<ChainParameter[] | any>;
+    getChainParameters(): Promise<ChainParameter[]>;
     getConfirmedTransaction(
       transactionID: string
     ): Promise<Record<string, unknown>>;


### PR DESCRIPTION
Removed the hardcoded max fee limit and got the provider to query the value on-chain the first time a transaction is prepared. 